### PR TITLE
Coverage sweep: report to codecov; informational statuses

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -28,3 +28,6 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+          # The org-wide token cannot imply a repository; the slug says
+          # which repo this upload is for.
+          slug: ${{ github.repository }}

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -23,3 +23,8 @@ jobs:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+# Coverage numbers without CI redness: the project/patch checks report their
+# figures but never fail — a coverage drop is information, not a broken build.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Part of the org-wide coverage sweep: the test job gains `julia-processcoverage` + `codecov-action` on the org-level `CODECOV_TOKEN` (the pattern verified across the org this week), `codecov.yml` makes the project/patch statuses informational — numbers and deltas on every PR, never a failed rollup — and README links move off the pre-transfer orgs where the sweep found them. After merge: one codecov-side activation click, then the first CI run posts the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)